### PR TITLE
Handle missing `author_username` in a cast

### DIFF
--- a/src/functions/index-casts.ts
+++ b/src/functions/index-casts.ts
@@ -20,7 +20,7 @@ export async function indexAllCasts(limit?: number) {
       thread_hash: c.threadHash,
       parent_hash: c.parentHash || null,
       author_fid: c.author.fid,
-      author_username: c.author.username,
+      author_username: c.author.username || null,
       author_display_name: c.author.displayName,
       author_pfp_url: c.author.pfp?.url || null,
       author_pfp_verified: c.author.pfp?.verified || false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,7 +100,7 @@ export interface FlattenedCast {
   thread_hash: string
   parent_hash: string | null
   author_fid: number
-  author_username: string
+  author_username: string | null
   author_display_name: string
   author_pfp_url: string | null
   author_pfp_verified: boolean | null

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@
  * @param {number} chunkSize Size of each chunk
  * @returns {array} Array of smaller chunks
  */
-export function breakIntoChunks(array: any[], chunkSize: number): Array<any> {
+export function breakIntoChunks<T>(array: T[], chunkSize: number): T[][] {
   const chunks = Array()
   for (let i = 0; i < array.length; i += chunkSize) {
     chunks.push(array.slice(i, i + chunkSize))


### PR DESCRIPTION
There are casts that are missing a `author_username`. In the current form, entering into supabase fails because a field is missing:

```
file:///.../dist/functions/index-casts.js:48
            throw new Error(JSON.stringify(error));
                  ^

Error: {"code":"PGRST102","details":null,"hint":null,"message":"All object keys must match"}
    at indexAllCasts (file:///Users/pal/side-projects/fc-interests/farcaster-indexer/dist/functions/index-casts.js:48:19)
```

This change makes `author_username` nullable, which allows it to be saved into the DB. 

A different way to solve this could be to skip the "bad" cast. Here's an example of a cast with missing `author_username`:

```
    "hash": "0x4269b7b92875324d52ae209ad688c725211100a88d5b0e08b737abe30ed74d83",
    "thread_hash": "0x4269b7b92875324d52ae209ad688c725211100a88d5b0e08b737abe30ed74d83",
    "parent_hash": null,
    "author_fid": 9101,
    "author_display_name": "test-1",
    "author_pfp_url": "https://i.imgur.com/4b1uA9M.jpg",
    "author_pfp_verified": false,
    "text": "test cast for 3, @mm-fc-test-3",
    "published_at": "2023-02-13T21:39:53.088Z",
    "mentions": [
      {
        "fid": 9112,
        "username": "mm-fc-test-3",
        "displayName": "test-3",
        "pfp": {
          "url": "https://i.imgur.com/pWtnbbO.jpg",
          "verified": false
        }
      }
    ],
    "replies_count": 0,
    "reactions_count": 2,
    "recasts_count": 1,
    "watches_count": 0,
    "parent_author_fid": null,
    "parent_author_username": null,
    "deleted": false
```

## Changes

* Make `author_username` nullable
* Add stronger typechecking to `breakIntoChunks` by limiting from `any` to type `T`. The editor is able to make better type inference as a result