### PR TITLE
Store v1 hashes for backwards compatibility

### DIFF
--- a/src/functions/index-casts.ts
+++ b/src/functions/index-casts.ts
@@ -15,7 +15,7 @@ export async function indexAllCasts(limit?: number) {
   const cleanedCasts = cleanCasts(allCasts)
 
   const formattedCasts: FlattenedCast[] = cleanedCasts.map((c) => {
-    return {
+    const cast: FlattenedCast = {
       hash: c.hash,
       thread_hash: c.threadHash,
       parent_hash: c.parentHash || null,
@@ -35,6 +35,15 @@ export async function indexAllCasts(limit?: number) {
       parent_author_username: c.parentAuthor?.username || null,
       deleted: false,
     }
+
+    // Retain v1 hashes for backwards compatibility
+    if (c.hash.length === 66) {
+      cast.hash_v1 = c.hash
+      cast.thread_hash_v1 = c.threadHash
+      cast.parent_hash_v1 = c.parentHash || null
+    }
+
+    return cast
   })
 
   // Break formattedCasts into chunks of 1000

--- a/src/functions/index-casts.ts
+++ b/src/functions/index-casts.ts
@@ -36,11 +36,11 @@ export async function indexAllCasts(limit?: number) {
       deleted: false,
     }
 
-    // Retain v1 hashes for backwards compatibility
-    if (c.hash.length === 66) {
-      cast.hash_v1 = c.hash
-      cast.thread_hash_v1 = c.threadHash
-      cast.parent_hash_v1 = c.parentHash || null
+    // Retain v1 hashes for backwards compatibility (remove after 3/21/2023)
+    if (c._hashV1) {
+      cast.hash_v1 = c._hashV1
+      cast.thread_hash_v1 = c._threadHashV1
+      cast.parent_hash_v1 = c._parentHashV1 || null
     }
 
     return cast

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,8 +97,11 @@ export interface FlattenedProfile {
 
 export interface FlattenedCast {
   hash: string
+  hash_v1?: string
   thread_hash: string
+  thread_hash_v1?: string
   parent_hash: string | null
+  parent_hash_v1?: string | null
   author_fid: number
   author_username: string | null
   author_display_name: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,8 +39,11 @@ export interface Profile {
 
 export interface Cast {
   hash: string
+  _hashV1?: string
   threadHash: string
-  parentHash: string
+  _threadHashV1?: string
+  parentHash: string | null
+  _parentHashV1?: string | null
   author: {
     fid: number
     username: string

--- a/supabase/migrations/20230306224217_hash-migration.sql
+++ b/supabase/migrations/20230306224217_hash-migration.sql
@@ -1,0 +1,7 @@
+alter table "public"."casts" add column "hash_v1" text;
+
+alter table "public"."casts" add column "parent_hash_v1" text;
+
+alter table "public"."casts" add column "thread_hash_v1" text;
+
+


### PR DESCRIPTION
The [Warpcast API migration process](https://warpcast.notion.site/Warpcast-API-Hash-Migration-Public-ccdd6de8ac604783b9596cfd623ddbac) outlines that hashes on all casts will be updated in the coming weeks. To avoid broken links on [Searchcaster](https://searchcaster.xyz/), we want to store both versions for a period of time.

The `hash` primary key will remain untouched, so will start picking up the new hashes upon the Warpcast migration on March 14th. To update the hashes on old casts and populate v1 hashes, wipe the `casts` table then run `yarn seed` between March 14th and March 21st.

Note: this includes a database migration.

This should be merged prior to https://github.com/gskril/searchcaster/pull/21